### PR TITLE
[RC] Version 1.2.0 (New Components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfootco/skogen",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Tailwind and React design library built to be simple, effective & maintainable",
   "exports": {
     ".": {

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,8 +1,14 @@
+import { useId } from 'react';
 import { cn } from '../../utils/cn';
 
 interface CheckboxProps {
   checked: boolean;
   label: string;
+  /** Stable id; falls back to a generated one so multiple checkboxes never collide. */
+  id?: string;
+  name?: string;
+  required?: boolean;
+  disabled?: boolean;
   onChange: () => void;
   className?: string;
   labelClassName?: string;
@@ -11,21 +17,35 @@ interface CheckboxProps {
 const Checkbox = ({
   checked,
   label,
+  id,
+  name,
+  required = false,
+  disabled = false,
   onChange,
   className = '',
   labelClassName = '',
 }: CheckboxProps) => {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
   return (
     <div className={cn('mb-4 inline-flex items-center', className)}>
       <input
         checked={checked}
-        id="default-checkbox"
+        id={inputId}
+        name={name}
         type="checkbox"
-        className="h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600"
+        required={required}
+        disabled={disabled}
+        aria-required={required || undefined}
+        className={cn(
+          'h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600',
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        )}
         onChange={onChange}
       />
       <label
-        htmlFor="default-checkbox"
+        htmlFor={inputId}
         className={cn(
           'ms-2 text-sm font-medium text-gray-900 dark:text-gray-200',
           labelClassName,

--- a/src/components/DateInput/DateInput.stories.tsx
+++ b/src/components/DateInput/DateInput.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import DateInput from '.';
+
+const meta: Meta<typeof DateInput> = {
+  title: 'Components/DateInput',
+  component: DateInput,
+  tags: ['autodocs'],
+  args: { id: 'dob', label: 'Date of birth', value: '', onChange: () => {} },
+};
+
+export default meta;
+type Story = StoryObj<typeof DateInput>;
+
+export const Default: Story = {};
+export const DateTime: Story = { args: { type: 'datetime-local', label: 'Starts at' } };
+export const Required: Story = { args: { required: true } };
+export const WithError: Story = { args: { error: 'Invalid date' } };

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+import { cn } from '../../utils/cn';
+import FormField from '../FormField';
+
+interface DateInputProps {
+  id: string;
+  label?: string | React.ReactNode;
+  value: string;
+  type?: 'date' | 'datetime-local' | 'time';
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  min?: string;
+  max?: string;
+  className?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
+  (
+    {
+      id,
+      label,
+      value,
+      type = 'date',
+      hint,
+      error,
+      required = false,
+      disabled = false,
+      min,
+      max,
+      className = '',
+      onChange = () => {},
+    },
+    ref,
+  ) => {
+    const borderStyling = error
+      ? 'border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+      : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:focus:border-blue-500';
+
+    return (
+      <FormField
+        id={id}
+        label={label}
+        hint={hint}
+        error={error}
+        required={required}
+      >
+        {(aria) => (
+          <input
+            {...aria}
+            ref={ref}
+            type={type}
+            value={value}
+            min={min}
+            max={max}
+            required={required}
+            disabled={disabled}
+            onChange={onChange}
+            className={cn(
+              `block w-full rounded-lg border bg-gray-50 p-2.5 text-sm text-gray-900 dark:bg-gray-700 dark:text-white ${borderStyling} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className}`,
+            )}
+          />
+        )}
+      </FormField>
+    );
+  },
+);
+
+DateInput.displayName = 'DateInput';
+
+export default DateInput;

--- a/src/components/FileInput/FileInput.stories.tsx
+++ b/src/components/FileInput/FileInput.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import FileInput from '.';
+
+const meta: Meta<typeof FileInput> = {
+  title: 'Components/FileInput',
+  component: FileInput,
+  tags: ['autodocs'],
+  args: { id: 'doc', label: 'Upload document', onChange: () => {} },
+};
+
+export default meta;
+type Story = StoryObj<typeof FileInput>;
+
+export const Default: Story = {};
+export const PdfOnly: Story = { args: { accept: '.pdf', hint: 'PDF files only' } };
+export const Multiple: Story = { args: { multiple: true } };
+export const WithError: Story = { args: { error: 'A file is required' } };

--- a/src/components/FileInput/index.tsx
+++ b/src/components/FileInput/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+import { cn } from '../../utils/cn';
+import FormField from '../FormField';
+
+interface FileInputProps {
+  id: string;
+  label?: string | React.ReactNode;
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  accept?: string;
+  multiple?: boolean;
+  className?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
+  (
+    {
+      id,
+      label,
+      hint,
+      error,
+      required = false,
+      disabled = false,
+      accept,
+      multiple = false,
+      className = '',
+      onChange = () => {},
+    },
+    ref,
+  ) => {
+    const borderStyling = error ? 'border-red-500' : 'border-gray-300 dark:border-gray-600';
+
+    return (
+      <FormField
+        id={id}
+        label={label}
+        hint={hint}
+        error={error}
+        required={required}
+      >
+        {(aria) => (
+          <input
+            {...aria}
+            ref={ref}
+            type="file"
+            accept={accept}
+            multiple={multiple}
+            required={required}
+            disabled={disabled}
+            onChange={onChange}
+            className={cn(
+              `block w-full rounded-lg border bg-gray-50 text-sm text-gray-900 file:mr-4 file:border-0 file:bg-gray-100 file:px-4 file:py-2.5 file:text-sm file:font-medium file:text-gray-700 dark:bg-gray-700 dark:text-white dark:file:bg-gray-600 dark:file:text-gray-100 ${borderStyling} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className}`,
+            )}
+          />
+        )}
+      </FormField>
+    );
+  },
+);
+
+FileInput.displayName = 'FileInput';
+
+export default FileInput;

--- a/src/components/FormField/FormField.stories.tsx
+++ b/src/components/FormField/FormField.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import FormField from '.';
+
+const meta: Meta<typeof FormField> = {
+  title: 'Components/FormField',
+  component: FormField,
+  tags: ['autodocs'],
+  args: {
+    id: 'field',
+    label: 'Field label',
+    children: (aria) => (
+      <input
+        {...aria}
+        className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm"
+      />
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FormField>;
+
+export const Default: Story = {};
+export const WithHint: Story = { args: { hint: 'Some guidance for this field' } };
+export const Required: Story = { args: { required: true } };
+export const WithError: Story = { args: { error: 'This field is required' } };

--- a/src/components/FormField/index.tsx
+++ b/src/components/FormField/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+/** ARIA props a control should spread to wire itself to its label/hint/error. */
+export interface FieldAria {
+  id: string;
+  'aria-invalid': boolean | undefined;
+  'aria-describedby': string | undefined;
+  'aria-required': boolean | undefined;
+}
+
+interface FormFieldProps {
+  id: string;
+  label?: string | React.ReactNode;
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  className?: string;
+  /**
+   * Render-prop receiving the ARIA props to spread onto the control. Wiring it
+   * here keeps every field's accessibility consistent (aria-invalid /
+   * aria-describedby / aria-required) without each input re-implementing it.
+   */
+  children: (aria: FieldAria) => React.ReactNode;
+}
+
+/** Compose a non-empty `aria-describedby` from the hint and error ids. */
+export const describedBy = (
+  ids: Array<string | false | undefined>,
+): string | undefined => {
+  const present = ids.filter(Boolean) as string[];
+  return present.length ? present.join(' ') : undefined;
+};
+
+const FormField = ({
+  id,
+  label,
+  hint,
+  error,
+  required = false,
+  className = '',
+  children,
+}: FormFieldProps) => {
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+
+  const aria: FieldAria = {
+    id,
+    'aria-invalid': error ? true : undefined,
+    'aria-describedby': describedBy([hintId, errorId]),
+    'aria-required': required || undefined,
+  };
+
+  return (
+    <div className={cn('w-full', className)}>
+      {label && (
+        <label
+          htmlFor={id}
+          className="mb-2 block text-sm font-medium text-gray-900 dark:text-gray-200"
+        >
+          {label}
+          {required && (
+            <span className="ms-1 text-red-500" aria-hidden="true">
+              *
+            </span>
+          )}
+        </label>
+      )}
+      {children(aria)}
+      {hint && !error && (
+        <p
+          id={hintId}
+          className="mt-1 text-sm text-gray-500 dark:text-gray-400"
+        >
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className="mt-1 text-sm text-red-500">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default FormField;

--- a/src/components/InputField/index.tsx
+++ b/src/components/InputField/index.tsx
@@ -57,6 +57,9 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
           id={id}
           value={value}
           type={type}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? `${id}-error` : undefined}
+          aria-required={required || undefined}
           className={cn(
             `block w-full rounded-lg border bg-gray-50 p-2.5 text-sm text-gray-900 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 ${sizeDictionary[size]} ${borderStyling} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className}`,
           )}
@@ -67,9 +70,11 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
           ref={ref}
         />
         {error && (
-          <Typography variant="p" color="error" className="mb-2">
-            {error}
-          </Typography>
+          <span id={`${id}-error`}>
+            <Typography variant="p" color="error" className="mb-2">
+              {error}
+            </Typography>
+          </span>
         )}
       </div>
     );

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import MultiSelect from '.';
+
+const meta: Meta<typeof MultiSelect> = {
+  title: 'Components/MultiSelect',
+  component: MultiSelect,
+  tags: ['autodocs'],
+  args: {
+    id: 'fruit',
+    label: 'Fruits',
+    value: [],
+    options: [
+      { value: 'a', label: 'Apple' },
+      { value: 'b', label: 'Banana' },
+      { value: 'c', label: 'Cherry' },
+      { value: 'd', label: 'Date' },
+    ],
+    onChange: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MultiSelect>;
+
+export const Default: Story = {};
+export const WithSelection: Story = { args: { value: ['a', 'c'] } };
+export const Required: Story = { args: { required: true } };
+export const WithError: Story = { args: { error: 'Select at least one' } };

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { cn } from '../../utils/cn';
+import FormField from '../FormField';
+
+interface MultiSelectOption {
+  value: string;
+  label: string;
+}
+
+interface MultiSelectProps {
+  id: string;
+  label?: string | React.ReactNode;
+  options: MultiSelectOption[];
+  value: string[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  onChange: (value: string[]) => void;
+}
+
+const MultiSelect = ({
+  id,
+  label,
+  options,
+  value,
+  placeholder = 'Select…',
+  searchPlaceholder = 'Search…',
+  hint,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  onChange,
+}: MultiSelectProps) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+
+  const filtered = useMemo(
+    () =>
+      options.filter((o) =>
+        o.label.toLowerCase().includes(search.trim().toLowerCase()),
+      ),
+    [options, search],
+  );
+
+  const toggle = (optionValue: string) => {
+    if (selectedSet.has(optionValue)) {
+      onChange(value.filter((v) => v !== optionValue));
+    } else {
+      onChange([...value, optionValue]);
+    }
+  };
+
+  const summary =
+    value.length === 0
+      ? placeholder
+      : options
+          .filter((o) => selectedSet.has(o.value))
+          .map((o) => o.label)
+          .join(', ');
+
+  return (
+    <FormField
+      id={id}
+      label={label}
+      hint={hint}
+      error={error}
+      required={required}
+      className={className}
+    >
+      {(aria) => (
+        <div ref={containerRef} className="relative">
+          <button
+            id={aria.id}
+            type="button"
+            aria-haspopup="listbox"
+            aria-expanded={open}
+            aria-controls={listId}
+            aria-invalid={aria['aria-invalid']}
+            aria-describedby={aria['aria-describedby']}
+            aria-required={aria['aria-required']}
+            disabled={disabled}
+            onClick={() => setOpen((prev) => !prev)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setOpen(false);
+            }}
+            className={cn(
+              'flex w-full items-center justify-between rounded-lg border bg-gray-50 p-2.5 text-left text-sm text-gray-900 dark:bg-gray-700 dark:text-white',
+              error
+                ? 'border-red-500'
+                : 'border-gray-300 dark:border-gray-600',
+              disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+            )}
+          >
+            <span className={cn(value.length === 0 && 'text-gray-400')}>
+              {summary}
+            </span>
+            <span aria-hidden="true" className="ms-2">
+              ▾
+            </span>
+          </button>
+
+          {open && (
+            <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-700">
+              <div className="p-2">
+                <input
+                  type="text"
+                  value={search}
+                  placeholder={searchPlaceholder}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="block w-full rounded-md border border-gray-300 bg-gray-50 p-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                />
+              </div>
+              <ul
+                id={listId}
+                role="listbox"
+                aria-multiselectable="true"
+                className="max-h-56 overflow-auto py-1"
+              >
+                {filtered.length === 0 && (
+                  <li className="px-3 py-2 text-sm text-gray-400">
+                    No matches
+                  </li>
+                )}
+                {filtered.map((option) => {
+                  const checked = selectedSet.has(option.value);
+                  return (
+                    <li key={option.value} role="option" aria-selected={checked}>
+                      <label className="flex cursor-pointer items-center px-3 py-2 text-sm text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-600">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(option.value)}
+                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
+                        <span className="ms-2">{option.label}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </FormField>
+  );
+};
+
+export default MultiSelect;

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import RadioGroup from '.';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  tags: ['autodocs'],
+  args: {
+    id: 'fruit',
+    label: 'Favourite fruit',
+    value: 'a',
+    options: [
+      { value: 'a', label: 'Apple' },
+      { value: 'b', label: 'Banana' },
+      { value: 'c', label: 'Cherry' },
+    ],
+    onChange: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+export const Default: Story = {};
+export const Required: Story = { args: { required: true } };
+export const WithError: Story = { args: { error: 'Please choose one' } };
+export const Disabled: Story = { args: { disabled: true } };

--- a/src/components/RadioGroup/index.tsx
+++ b/src/components/RadioGroup/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../utils/cn';
+import FormField from '../FormField';
+
+interface RadioOption {
+  value: string;
+  label: string;
+}
+
+interface RadioGroupProps {
+  id: string;
+  label?: string | React.ReactNode;
+  options: RadioOption[];
+  value: string;
+  name?: string;
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  onChange: (value: string) => void;
+}
+
+const RadioGroup = ({
+  id,
+  label,
+  options,
+  value,
+  name,
+  hint,
+  error,
+  required = false,
+  disabled = false,
+  className = '',
+  onChange,
+}: RadioGroupProps) => {
+  const groupName = name ?? id;
+
+  return (
+    <FormField
+      id={id}
+      label={label}
+      hint={hint}
+      error={error}
+      required={required}
+      className={className}
+    >
+      {(aria) => (
+        <div
+          role="radiogroup"
+          aria-labelledby={label ? undefined : id}
+          aria-invalid={aria['aria-invalid']}
+          aria-describedby={aria['aria-describedby']}
+          className="flex flex-col gap-2"
+        >
+          {options.map((option) => {
+            const optionId = `${id}-${option.value}`;
+            return (
+              <label
+                key={option.value}
+                htmlFor={optionId}
+                className={cn(
+                  'inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-200',
+                  disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                )}
+              >
+                <input
+                  id={optionId}
+                  type="radio"
+                  name={groupName}
+                  value={option.value}
+                  checked={value === option.value}
+                  disabled={disabled}
+                  onChange={() => onChange(option.value)}
+                  className="h-4 w-4 border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600"
+                />
+                <span className="ms-2">{option.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </FormField>
+  );
+};
+
+export default RadioGroup;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -11,6 +11,8 @@ interface SelectProps {
   }[];
   selected: string | string[];
   multiple?: boolean;
+  required?: boolean;
+  error?: string;
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
@@ -21,10 +23,16 @@ const Select = ({
   className = '',
   multiple = false,
   selected = '',
+  required = false,
+  error = '',
   onChange,
 }: SelectProps) => {
+  const borderStyling = error
+    ? 'border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+    : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:focus:border-blue-500 dark:focus:ring-blue-500';
+
   return (
-    <form>
+    <div>
       {label && (
         <label
           htmlFor={id}
@@ -36,8 +44,12 @@ const Select = ({
       <select
         id={id}
         value={selected}
+        required={required}
+        aria-required={required || undefined}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${id}-error` : undefined}
         className={cn(
-          `block w-full appearance-none rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500 ${className}`,
+          `block w-full appearance-none rounded-lg border bg-gray-50 p-2.5 text-sm text-gray-900 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 ${borderStyling} ${className}`,
         )}
         multiple={multiple}
         onChange={onChange}
@@ -53,7 +65,12 @@ const Select = ({
           </option>
         ))}
       </select>
-    </form>
+      {error && (
+        <p id={`${id}-error`} className="mt-1 text-sm text-red-500">
+          {error}
+        </p>
+      )}
+    </div>
   );
 };
 

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -54,6 +54,9 @@ const TextArea = ({
       <textarea
         id={id}
         value={value}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? `${id}-error` : undefined}
+        aria-required={required || undefined}
         className={cn(
           `block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900  ${sizeDictionary[size]} ${borderStyling} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className}`,
         )}
@@ -63,9 +66,11 @@ const TextArea = ({
         onChange={onChange}
       />
       {error && (
-        <Typography variant="p" color="error" className="mt-1">
-          {error}
-        </Typography>
+        <span id={`${id}-error`}>
+          <Typography variant="p" color="error" className="mt-1">
+            {error}
+          </Typography>
+        </span>
       )}
     </div>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,15 @@
 export { default as Badge } from './components/Badge';
 export { default as Button } from './components/Button';
 export { default as Checkbox } from './components/Checkbox';
+export { default as DateInput } from './components/DateInput';
 export { default as Divider } from './components/Divider';
+export { default as FileInput } from './components/FileInput';
+export { default as FormField } from './components/FormField';
+export type { FieldAria } from './components/FormField';
 export { default as InputField } from './components/InputField';
 export { default as InputMask } from './components/InputMask';
+export { default as MultiSelect } from './components/MultiSelect';
+export { default as RadioGroup } from './components/RadioGroup';
 export { default as Select } from './components/Select';
 export { default as TextArea } from './components/TextArea';
 export { default as Toast } from './components/Toast';

--- a/src/tests/components/DateInput.test.tsx
+++ b/src/tests/components/DateInput.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import DateInput from '../../components/DateInput';
+
+describe('DateInput', () => {
+  const defaultProps = {
+    id: 'dob',
+    label: 'Date of birth',
+    value: '',
+  };
+
+  it('renders a date input with its label', () => {
+    render(<DateInput {...defaultProps} />);
+    expect(screen.getByText('Date of birth')).toBeInTheDocument();
+  });
+
+  it('calls onChange when the value changes', () => {
+    const onChange = vi.fn();
+    render(<DateInput {...defaultProps} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Date of birth'), {
+      target: { value: '2026-01-01' },
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('wires aria-invalid + describedby on error', () => {
+    render(<DateInput {...defaultProps} error="Invalid date" />);
+    const input = screen.getByLabelText('Date of birth');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'dob-error');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<DateInput {...defaultProps} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+});

--- a/src/tests/components/FileInput.test.tsx
+++ b/src/tests/components/FileInput.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import FileInput from '../../components/FileInput';
+
+describe('FileInput', () => {
+  const defaultProps = { id: 'doc', label: 'Document' };
+
+  it('renders a file input with its label', () => {
+    render(<FileInput {...defaultProps} />);
+    expect(screen.getByText('Document')).toBeInTheDocument();
+    const input = document.getElementById('doc') as HTMLInputElement;
+    expect(input.type).toBe('file');
+  });
+
+  it('passes accept and multiple through', () => {
+    render(<FileInput {...defaultProps} accept=".pdf" multiple />);
+    const input = document.getElementById('doc') as HTMLInputElement;
+    expect(input).toHaveAttribute('accept', '.pdf');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  it('wires aria-invalid on error', () => {
+    render(<FileInput {...defaultProps} error="Required" />);
+    const input = document.getElementById('doc') as HTMLInputElement;
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'doc-error');
+  });
+});

--- a/src/tests/components/FormField.test.tsx
+++ b/src/tests/components/FormField.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import FormField, { describedBy } from '../../components/FormField';
+
+describe('FormField', () => {
+  it('wires aria-invalid and aria-describedby to the control on error', () => {
+    render(
+      <FormField id="f" label="Name" error="Required">
+        {(aria) => <input aria-label="control" {...aria} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText('control');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'f-error');
+    expect(screen.getByText('Required')).toHaveAttribute('id', 'f-error');
+  });
+
+  it('exposes the hint via aria-describedby when there is no error', () => {
+    render(
+      <FormField id="f" label="Name" hint="Helpful">
+        {(aria) => <input aria-label="control" {...aria} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('control')).toHaveAttribute(
+      'aria-describedby',
+      'f-hint',
+    );
+  });
+
+  it('marks required fields with aria-required and a visual marker', () => {
+    render(
+      <FormField id="f" label="Name" required>
+        {(aria) => <input aria-label="control" {...aria} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText('control')).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+
+  it('describedBy joins present ids and drops empty ones', () => {
+    expect(describedBy(['a', undefined, 'b'])).toBe('a b');
+    expect(describedBy([undefined, false])).toBeUndefined();
+  });
+});

--- a/src/tests/components/MultiSelect.test.tsx
+++ b/src/tests/components/MultiSelect.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MultiSelect from '../../components/MultiSelect';
+
+const options = [
+  { value: 'a', label: 'Apple' },
+  { value: 'b', label: 'Banana' },
+  { value: 'c', label: 'Cherry' },
+];
+
+describe('MultiSelect', () => {
+  const defaultProps = {
+    id: 'fruit',
+    label: 'Fruit',
+    options,
+    value: [] as string[],
+    onChange: () => {},
+  };
+
+  it('shows the placeholder when nothing is selected', () => {
+    render(<MultiSelect {...defaultProps} placeholder="Choose fruit" />);
+    expect(screen.getByText('Choose fruit')).toBeInTheDocument();
+  });
+
+  it('opens the panel and lists options', () => {
+    render(<MultiSelect {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('filters options by search text', () => {
+    render(<MultiSelect {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByPlaceholderText('Search…'), {
+      target: { value: 'ban' },
+    });
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+  });
+
+  it('toggles selection via onChange', () => {
+    const onChange = vi.fn();
+    render(<MultiSelect {...defaultProps} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByLabelText('Cherry'));
+    expect(onChange).toHaveBeenCalledWith(['c']);
+  });
+
+  it('summarises selected labels', () => {
+    render(<MultiSelect {...defaultProps} value={['a', 'c']} />);
+    expect(screen.getByText('Apple, Cherry')).toBeInTheDocument();
+  });
+
+  it('exposes aria-invalid on error', () => {
+    render(<MultiSelect {...defaultProps} error="Pick at least one" />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+});

--- a/src/tests/components/RadioGroup.test.tsx
+++ b/src/tests/components/RadioGroup.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import RadioGroup from '../../components/RadioGroup';
+
+const options = [
+  { value: 'a', label: 'Apple' },
+  { value: 'b', label: 'Banana' },
+];
+
+describe('RadioGroup', () => {
+  const defaultProps = {
+    id: 'fruit',
+    label: 'Fruit',
+    options,
+    value: 'a',
+    onChange: () => {},
+  };
+
+  it('renders a radiogroup with one input per option', () => {
+    render(<RadioGroup {...defaultProps} />);
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('marks the selected option as checked', () => {
+    render(<RadioGroup {...defaultProps} value="b" />);
+    expect(screen.getByLabelText('Banana')).toBeChecked();
+    expect(screen.getByLabelText('Apple')).not.toBeChecked();
+  });
+
+  it('calls onChange with the chosen value', () => {
+    const onChange = vi.fn();
+    render(<RadioGroup {...defaultProps} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('Banana'));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('exposes aria-invalid on error', () => {
+    render(<RadioGroup {...defaultProps} error="Pick one" />);
+    expect(screen.getByRole('radiogroup')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+    expect(screen.getByText('Pick one')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Expands the form toolkit so application-style forms can be built out of Skogen primitives. Adds four new field components, introduces a shared `FormField` wrapper that standardises labels, hints, errors and accessibility wiring, and retrofits the existing form controls to use the same patterns. Bumps the package to 1.2.0.

## Changes

- **New `FormField` primitive** — a render-prop wrapper that owns label, required marker, hint and error rendering and hands each control a consistent set of ARIA props (`aria-invalid`, `aria-describedby`, `aria-required`). Exported alongside its `FieldAria` type and a `describedBy` helper.
- **New field components**, all built on `FormField`:
  - `DateInput` — date / datetime-local / time input with min/max, ref forwarding.
  - `FileInput` — file upload with `accept` and `multiple`, ref forwarding.
  - `RadioGroup` — accessible `role="radiogroup"` set of options.
  - `MultiSelect` — searchable, multi-select dropdown with outside-click dismissal and listbox semantics.
- **Accessibility/consistency upgrades to existing controls:**
  - `Checkbox` now takes `id`/`name`/`required`/`disabled`, generates a stable id (fixing the previously hardcoded `default-checkbox` collision), and reflects disabled state.
  - `InputField` and `TextArea` now wire `aria-invalid` / `aria-describedby` / `aria-required` and give their error text an addressable id.
  - `Select` gains `required` and `error` support (with matching ARIA), and its wrapping `<form>` was changed to a `<div>`.
- Storybook stories and Vitest/RTL tests for every new component, plus coverage of the `describedBy` helper.
- All new components exported from the package entrypoint.

## Notes for reviewers

- `Select`'s root element changed from `<form>` to `<div>`. This is the right call for a reusable control, but worth confirming no consumer relied on the implicit form element.
- `MultiSelect` registers a `mousedown` listener on `document` while open for outside-click dismissal; cleanup is handled in the effect teardown.
